### PR TITLE
ADD consumption and pricing stats to frontend

### DIFF
--- a/App/css/main.css
+++ b/App/css/main.css
@@ -45,7 +45,8 @@ body {
 }
 
 .subtitle,
-.control-group label {
+.control-group label,
+.stats-label {
   color: var(--grey);
 }
 
@@ -107,4 +108,12 @@ header .subtitle {
   width: 1.5em;
   background-color: var(--primary-color);
   border-radius: 50%;
+}
+
+.graph {
+  max-height: 500px;
+}
+
+.mt-10 {
+  margin-top: 40px;
 }

--- a/App/css/main.css
+++ b/App/css/main.css
@@ -114,6 +114,6 @@ header .subtitle {
   max-height: 500px;
 }
 
-.mt-10 {
+.mt-40 {
   margin-top: 40px;
 }

--- a/App/css/main.css
+++ b/App/css/main.css
@@ -84,11 +84,11 @@ header .subtitle {
   padding: 0.25em 1em;
   border: 1px solid var(--light-grey);
   font-size: 18px;
-  border-radius: 10em;
+  border-radius: 5px;
 }
 
 .control-group.slider {
-  width: 50vw;
+  width: 100%;
 }
 
 .control-group .slider {

--- a/App/index.html
+++ b/App/index.html
@@ -7,11 +7,11 @@
     <title>
       Water You Doing, New York? | JAKK Team | Borealis AI Let's Solve It
     </title>
-    <link rel="stylesheet" href="./css/main.css">
     <!-- Bootstrap 4 -->
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
       integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"
       crossorigin="anonymous">
+    <link rel="stylesheet" href="./css/main.css">
   </head>
   <body>
     <div class="container">

--- a/App/index.html
+++ b/App/index.html
@@ -7,17 +7,25 @@
     <title>
       Water You Doing, New York? | JAKK Team | Borealis AI Let's Solve It
     </title>
-    <link rel="stylesheet" href="./css/main.css" />
+    <!-- <link rel="styleshcounteet" href="./css/main.css" /> -->
+    <link rel="stylesheet" href="./css/main.css">
+    <!-- Bootstrap 4 -->
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
+      integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T"
+      crossorigin="anonymous">
   </head>
   <body>
     <div class="container">
-      <header>
-        <h1 class="heading1">Water You Doing, New York?</h1>
-        <p class="subtitle">by JAKK Team</p>
-      </header>
+      <div class="row">
+        <header class="col-12">
+          <h1 class="heading1">Water You Doing, New York?</h1>
+          <p class="subtitle">By: JAKK Team</p>
+        </header>
+      </div>
       <main>
-        <div class="controls">
-          <div class="control-group">
+        <!-- Location and time span -->
+        <div class="row">
+          <div class="col-md-3 col-12 control-group">
             <label for="city">Location</label>
             <select name="city" id="city" class="select">
               <option value="Queens">Queens</option>
@@ -25,7 +33,7 @@
               <option value="Brooklyn">Brooklyn</option>
             </select>
           </div>
-          <div class="control-group slider">
+          <div class="col-md-9 col-12 control-group slider">
             <label for="timeSpan">Time Span</label>
             <input
               type="range"
@@ -38,6 +46,67 @@
             />
           </div>
         </div>
+        <!-- Consumption and pricing -->
+        <div class="row">
+          <!-- Consumption (with mock data) -->
+          <div class="col-md-6 col-12">
+            <div class="row">
+              <h5>Consumption (Hundred Cubic Feet)</h5>
+            </div>
+            <div class="row">
+              <div class="col">
+                Average
+              </div>
+              <div class="col">
+                Maximum
+              </div>
+              <div class="col">
+                Minimum
+              </div>
+            </div>
+            <div class="row">
+              <div class="col">
+                <b>543</b>
+              </div>
+              <div class="col">
+                <b>1380</b>
+              </div>
+              <div class="col">
+                <b>213</b>
+              </div>
+            </div>
+          </div>
+          <!-- Pricing (with mock data) -->
+          <div class="col-md-6 col-12">
+            <div class="row">
+              <h5>Pricing ($USD)</h5>
+            </div>
+            <div class="row">
+              <div class="col">
+                Average
+              </div>
+              <div class="col">
+                Maximum
+              </div>
+              <div class="col">
+                Minimum
+              </div>
+            </div>
+            <div class="row">
+              <div class="col">
+                <b>$10321.12</b>
+              </div>
+              <div class="col">
+                <b>$25506.32</b>
+              </div>
+              <div class="col">
+                <b>$3839.69</b>
+              </div>
+            </div>
+          </div>
+
+        </div>
+
         <canvas id="graph" class="graph"></canvas>
       </main>
     </div>

--- a/App/index.html
+++ b/App/index.html
@@ -7,7 +7,6 @@
     <title>
       Water You Doing, New York? | JAKK Team | Borealis AI Let's Solve It
     </title>
-    <!-- <link rel="styleshcounteet" href="./css/main.css" /> -->
     <link rel="stylesheet" href="./css/main.css">
     <!-- Bootstrap 4 -->
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
@@ -51,7 +50,7 @@
           </div>
         </div>
         <!-- Consumption and pricing -->
-        <div class="row mt-10">
+        <div class="row mt-40">
           <!-- Consumption (with mock data) -->
           <div class="col-md-6 col-12">
             <div class="row">

--- a/App/index.html
+++ b/App/index.html
@@ -28,9 +28,13 @@
           <div class="col-md-3 col-12 control-group">
             <label for="city">Location</label>
             <select name="city" id="city" class="select">
-              <option value="Queens">Queens</option>
               <option value="New York">New York</option>
+              <option value="Queens">Queens</option>
               <option value="Brooklyn">Brooklyn</option>
+              <option value="Bronx">Bronx</option>
+              <option value="Manhattan">Manhattan</option>
+              <option value="Staten Island">Staten Island</option>
+              <option value="FHA">FHA</option>
             </select>
           </div>
           <div class="col-md-9 col-12 control-group slider">
@@ -47,13 +51,13 @@
           </div>
         </div>
         <!-- Consumption and pricing -->
-        <div class="row">
+        <div class="row mt-10">
           <!-- Consumption (with mock data) -->
           <div class="col-md-6 col-12">
             <div class="row">
               <h5>Consumption (Hundred Cubic Feet)</h5>
             </div>
-            <div class="row">
+            <div class="row stats-label">
               <div class="col">
                 Average
               </div>
@@ -66,13 +70,13 @@
             </div>
             <div class="row">
               <div class="col">
-                <b>543</b>
+                <b id="avg-consume">543</b>
               </div>
               <div class="col">
-                <b>1380</b>
+                <b id="max-consume">1380</b>
               </div>
               <div class="col">
-                <b>213</b>
+                <b id="min-consume">213</b>
               </div>
             </div>
           </div>
@@ -81,7 +85,7 @@
             <div class="row">
               <h5>Pricing ($USD)</h5>
             </div>
-            <div class="row">
+            <div class="row stats-label">
               <div class="col">
                 Average
               </div>
@@ -94,19 +98,17 @@
             </div>
             <div class="row">
               <div class="col">
-                <b>$10321.12</b>
+                <b id="avg-price">$10321.12</b>
               </div>
               <div class="col">
-                <b>$25506.32</b>
+                <b id="max-price">$25506.32</b>
               </div>
               <div class="col">
-                <b>$3839.69</b>
+                <b id="min-price">$3839.69</b>
               </div>
             </div>
           </div>
-
         </div>
-
         <canvas id="graph" class="graph"></canvas>
       </main>
     </div>


### PR DESCRIPTION
## Overview
Add the "Consumption" and "Pricing" sections to the frontend.

### Features
- Used Bootstrap 4 for a scalable design that works on phones as well as desktops
- Added `max-height` constraint to the graph to avoid a bug where the graph becomes extremely tall