### PR TITLE
FIX mobile layout stats formatting failure

### DIFF
--- a/App/index.html
+++ b/App/index.html
@@ -57,24 +57,24 @@
               <h5>Consumption (Hundred Cubic Feet)</h5>
             </div>
             <div class="row stats-label">
-              <div class="col">
+              <div class="col-4">
                 Average
               </div>
-              <div class="col">
+              <div class="col-4">
                 Maximum
               </div>
-              <div class="col">
+              <div class="col-4">
                 Minimum
               </div>
             </div>
             <div class="row">
-              <div class="col">
+              <div class="col-4">
                 <b id="avg-consume">543</b>
               </div>
-              <div class="col">
+              <div class="col-4">
                 <b id="max-consume">1380</b>
               </div>
-              <div class="col">
+              <div class="col-4">
                 <b id="min-consume">213</b>
               </div>
             </div>
@@ -85,24 +85,24 @@
               <h5>Pricing ($USD)</h5>
             </div>
             <div class="row stats-label">
-              <div class="col">
+              <div class="col-4">
                 Average
               </div>
-              <div class="col">
+              <div class="col-4">
                 Maximum
               </div>
-              <div class="col">
+              <div class="col-4">
                 Minimum
               </div>
             </div>
             <div class="row">
-              <div class="col">
+              <div class="col-4">
                 <b id="avg-price">$10321.12</b>
               </div>
-              <div class="col">
+              <div class="col-4">
                 <b id="max-price">$25506.32</b>
               </div>
-              <div class="col">
+              <div class="col-4">
                 <b id="min-price">$3839.69</b>
               </div>
             </div>


### PR DESCRIPTION
## Overview
Fixed a formatting failure that would not align the statistics properly on mobile.

> Before correcting the error.

![Screenshot_2021-04-09_14-03-34](https://user-images.githubusercontent.com/31634087/114240530-80079480-993c-11eb-86c9-d790bc1e73ab.png)

> After correcting the error.

![Screenshot_2021-04-09_14-05-59](https://user-images.githubusercontent.com/31634087/114240683-c0ffa900-993c-11eb-972d-1d39b0903879.png)

