### PR TITLE
Correctly set red line for prediction data

### DIFF
--- a/App/js/UserInterface.js
+++ b/App/js/UserInterface.js
@@ -145,17 +145,22 @@ class UserInterface {
    * dropdown menu, and the time span slider.
    */
   async setGraph() {
-    this.setupMultiColorLine(70);
     let regionData = await this.api.getWaterData(this.startDate, this.endDate, this.region);
 
     let times = []
     let waterData = []
+    let predictionIndex = 0;
+    let lastKnownDate = new Date('2020-04-01');
     regionData.forEach((element) => {
+      if(Date.parse(element[0]) < lastKnownDate)
+        ++predictionIndex;
+
       times.push(element[0])
       waterData.push(element[1])
     })
 
     // now graph!
+    this.setupMultiColorLine(predictionIndex);
     this.resetGraph();
     const ctx = document.getElementById('graph').getContext('2d')
 

--- a/App/js/start.js
+++ b/App/js/start.js
@@ -1,4 +1,4 @@
-let ui = new UserInterface('2013-01-01', '2020-01-01', 'new york');
+let ui = new UserInterface('2013-01-01', '2026-01-01', 'new york');
 
 async function setUserInterface() {
   await ui.setGraph();


### PR DESCRIPTION
## Overview
Now the graph turns red at the correct index for all predictions.

### Notes
- The slider is not yet modified to support the future prediction
![Screenshot_2021-04-14_20-29-55](https://user-images.githubusercontent.com/31634087/114810302-a7a59500-9d60-11eb-88ab-1e7c2e2bbc89.png)
